### PR TITLE
Hatchling Outfitter AND First Person Presence Compatibility Fix

### DIFF
--- a/CommonCameraUtil/Components/PlayerMeshHandler.cs
+++ b/CommonCameraUtil/Components/PlayerMeshHandler.cs
@@ -46,9 +46,9 @@ public class PlayerMeshHandler : MonoBehaviour
 	{
 		if (wearingHelmet != CommonCameraUtil.Instance.HatchlingOutfit?.GetPlayerHelmeted())
 		{
-            SetHeadVisibility(CommonCameraUtil.UsingCustomCamera());
-        }
-    }
+			SetHeadVisibility(CommonCameraUtil.UsingCustomCamera());
+		}
+	}
 
 	public void OnDestroy()
 	{

--- a/CommonCameraUtil/Components/PlayerMeshHandler.cs
+++ b/CommonCameraUtil/Components/PlayerMeshHandler.cs
@@ -44,11 +44,10 @@ public class PlayerMeshHandler : MonoBehaviour
 	public void Update()
 	{
         IHatchlingOutfit hatchlingOutfit = CommonCameraUtil.Instance.HatchlingOutfit;
-		try
+		if (hatchlingOutfit != null && wearingHelmet != hatchlingOutfit?.GetPlayerHelmeted())
 		{
-			if (wearingHelmet != hatchlingOutfit.GetPlayerHelmeted()) SetHeadVisibility(CommonCameraUtil.UsingCustomCamera());
+            SetHeadVisibility(CommonCameraUtil.UsingCustomCamera());
         }
-		catch (Exception) { }
     }
 
 	public void OnDestroy()

--- a/CommonCameraUtil/Components/PlayerMeshHandler.cs
+++ b/CommonCameraUtil/Components/PlayerMeshHandler.cs
@@ -12,6 +12,7 @@ public class PlayerMeshHandler : MonoBehaviour
 	private HazardDetector _hazardDetector;
 	private float fade = 0f;
 	private bool inFire = false;
+	private bool wearingHelmet = false;
 
 	private int _propID_Fade;
 
@@ -39,6 +40,16 @@ public class PlayerMeshHandler : MonoBehaviour
 
 		_animController = GetComponentInChildren<PlayerAnimController>();
 	}
+
+	public void Update()
+	{
+        IHatchlingOutfit hatchlingOutfit = CommonCameraUtil.Instance.HatchlingOutfit;
+		try
+		{
+			if (wearingHelmet != hatchlingOutfit.GetPlayerHelmeted()) SetHeadVisibility(CommonCameraUtil.UsingCustomCamera());
+        }
+		catch (Exception) { }
+    }
 
 	public void OnDestroy()
 	{
@@ -242,9 +253,7 @@ public class PlayerMeshHandler : MonoBehaviour
 		IHatchlingOutfit hatchlingOutfit = CommonCameraUtil.Instance.HatchlingOutfit;
 		try
 		{
-			bool wearingHelmet;
-			if (hatchlingOutfit != null) wearingHelmet = hatchlingOutfit.GetPlayerHelmeted();
-			else wearingHelmet = Locator.GetPlayerSuit().IsWearingHelmet();
+			wearingHelmet = (hatchlingOutfit != null) ? hatchlingOutfit.GetPlayerHelmeted() : Locator.GetPlayerSuit().IsWearingHelmet();
 
 			if (wearingHelmet)
 			{

--- a/CommonCameraUtil/Components/PlayerMeshHandler.cs
+++ b/CommonCameraUtil/Components/PlayerMeshHandler.cs
@@ -43,8 +43,7 @@ public class PlayerMeshHandler : MonoBehaviour
 
 	public void Update()
 	{
-        IHatchlingOutfit hatchlingOutfit = CommonCameraUtil.Instance.HatchlingOutfit;
-		if (hatchlingOutfit != null && wearingHelmet != hatchlingOutfit?.GetPlayerHelmeted())
+		if (wearingHelmet != CommonCameraUtil.Instance.HatchlingOutfit?.GetPlayerHelmeted())
 		{
             SetHeadVisibility(CommonCameraUtil.UsingCustomCamera());
         }

--- a/CommonCameraUtil/Components/ToolMaterialHandler.cs
+++ b/CommonCameraUtil/Components/ToolMaterialHandler.cs
@@ -67,9 +67,9 @@ public class ToolMaterialHandler : MonoBehaviour
 
 	public void OnToolUnequiped(PlayerTool tool)
 	{
-        // Put them back to normal when unequiping
-        //SetToolMaterials(false);
-        _heldTool = null;
+		// Put them back to normal when unequiping
+		//SetToolMaterials(false);
+		_heldTool = null;
 	}
 
 	public void OnSwitchActiveCamera(OWCamera camera)
@@ -81,8 +81,8 @@ public class ToolMaterialHandler : MonoBehaviour
 		else
 		{
 			SetToolMaterials(false);
-            // Double check we're still holding it
-            if (_heldTool != null && !_heldTool.IsEquipped()) _heldTool = null;
+			// Double check we're still holding it
+			if (_heldTool != null && !_heldTool.IsEquipped()) _heldTool = null;
 		}
 		if (_heldTool != null)
 		{
@@ -119,8 +119,8 @@ public class ToolMaterialHandler : MonoBehaviour
 	private void UpdateToolScale(PlayerTool tool)
 	{
 		if (resizingExemptTools.Contains(tool.name)) return;
-        tool.transform.localScale = CommonCameraUtil.UsingCustomCamera() ? new Vector3(2, 2, 2) : Vector3.one;
-    }
+		tool.transform.localScale = CommonCameraUtil.UsingCustomCamera() ? new Vector3(2, 2, 2) : Vector3.one;
+	}
 
 	public void Update()
 	{

--- a/CommonCameraUtil/Components/ToolMaterialHandler.cs
+++ b/CommonCameraUtil/Components/ToolMaterialHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using UnityEngine;
+using static UnityEngine.GridBrushBase;
 
 namespace CommonCameraUtil.Handlers;
 
@@ -61,14 +62,14 @@ public class ToolMaterialHandler : MonoBehaviour
 		else SetToolMaterials(true);
 
 		// We make some of the models look larger for the 3rd person view
-		if (!resizingExemptTools.Contains(tool.name)) tool.transform.localScale = new Vector3(2, 2, 2);
+		UpdateToolScale(tool);
 	}
 
 	public void OnToolUnequiped(PlayerTool tool)
 	{
-		// Put them back to normal when unequiping
-		//SetToolMaterials(false);
-		_heldTool = null;
+        // Put them back to normal when unequiping
+        //SetToolMaterials(false);
+        _heldTool = null;
 	}
 
 	public void OnSwitchActiveCamera(OWCamera camera)
@@ -80,8 +81,12 @@ public class ToolMaterialHandler : MonoBehaviour
 		else
 		{
 			SetToolMaterials(false);
-			// Double check we're still holding it
-			if (_heldTool != null && !_heldTool.IsEquipped()) _heldTool = null;
+            // Double check we're still holding it
+            if (_heldTool != null && !_heldTool.IsEquipped()) _heldTool = null;
+		}
+		if (_heldTool != null)
+		{
+			UpdateToolScale(_heldTool);
 		}
 	}
 
@@ -110,6 +115,12 @@ public class ToolMaterialHandler : MonoBehaviour
 			}
 		}
 	}
+
+	private void UpdateToolScale(PlayerTool tool)
+	{
+		if (resizingExemptTools.Contains(tool.name)) return;
+        tool.transform.localScale = CommonCameraUtil.UsingCustomCamera() ? new Vector3(2, 2, 2) : Vector3.one;
+    }
 
 	public void Update()
 	{


### PR DESCRIPTION
Makes it so that the player's head won't be missing if you change their helmet-worn state to a non-default value while in a custom camera.